### PR TITLE
feat: mobile logo with text

### DIFF
--- a/app/[lang]/_components/header/MobileHeader.tsx
+++ b/app/[lang]/_components/header/MobileHeader.tsx
@@ -11,7 +11,7 @@ import {IconCheck} from '@/app/[lang]/_icons/IconCheck';
 import {IconClose} from '@/app/[lang]/_icons/IconClose';
 import {IconMenu} from '@/app/[lang]/_icons/IconMenu';
 import {IconPlanet} from '@/app/[lang]/_icons/IconPlanet';
-import {IconShapeshift} from '@/app/[lang]/_icons/IconShapeshift';
+import {ShapeshiftLogo} from '@/app/[lang]/_icons/ShapeshiftLogo';
 import {appDao, appProducts, appResources, headerTabs} from '@/app/[lang]/_utils/constants';
 import {SUPPORTED_LANGUAGES} from '@/app/[lang]/_utils/i18nconfig';
 
@@ -73,7 +73,7 @@ export function MobileHeader({
 		<div className={'sticky top-0 z-50 lg:hidden'}>
 			<div className={'z-50 mt-6 flex w-full items-center justify-between rounded-2xl bg-headerBg p-4'}>
 				<LocalizedLink href={'/'}>
-					<IconShapeshift />
+					<ShapeshiftLogo />
 				</LocalizedLink>
 				<button
 					onClick={() => setIsMenuOpen(!isMenuOpen)}
@@ -87,7 +87,7 @@ export function MobileHeader({
 						className={'fixed left-0 top-0 z-50 h-screen w-full overflow-y-auto bg-bg px-4 py-6'}
 						{...mobileMenuAnimation}>
 						<div className={'flex items-center justify-between'}>
-							<IconShapeshift />
+							<ShapeshiftLogo />
 							<button
 								onClick={() => setIsMenuOpen(false)}
 								className={'min-w-[56px] rounded-[20px] border border-white/5 p-4'}>


### PR DESCRIPTION
Uses the logo with the "ShapeShift" text on mobile resolutions to assert the brand more (i.e. having the worse "ShapeShift", above the fold, on the homepage seems important to me).

Note: This is a Draft currently because before the initial publication I've made [this suggestion](https://discord.com/channels/554694662431178782/1203049223759855636/1376939011444310026) and  @Majorfi  (MOM) / @thesmithdao reported that there were "[issues with responsiveness](https://discord.com/channels/554694662431178782/1203049223759855636/1381660753588912279)".

I couldn't find any in my own tests, if they can clear up which issue and everyone involved is comfortable with the full logo here, we can make this a PR and merge.

Before: 
![image](https://github.com/user-attachments/assets/f531f31c-a0f9-496f-b7d2-ebbf43df5b0e)

After:
![image](https://github.com/user-attachments/assets/6b5a592e-12f9-4912-8c75-a40f64cfbfab)


